### PR TITLE
Sprint2/add bad request

### DIFF
--- a/src/main/java/com/github/martingaston/application/communications/Receiver.java
+++ b/src/main/java/com/github/martingaston/application/communications/Receiver.java
@@ -14,7 +14,13 @@ public class Receiver {
     }
 
     public String receiveLine() throws IOException {
-        return buffered.readLine();
+        String received = buffered.readLine();
+
+        if (received == null) {
+            return "";
+        }
+
+        return received;
     }
 
     public byte[] drainStream() throws IOException {

--- a/src/main/java/com/github/martingaston/application/http/RequestParser.java
+++ b/src/main/java/com/github/martingaston/application/http/RequestParser.java
@@ -20,6 +20,10 @@ public class RequestParser {
     private static RequestLine parseRequestLine(Client client) throws IOException {
         String[] separatedRequestLine = client.receive().split(" ");
 
+        if (separatedRequestLine.length != 3) {
+            return new RequestLine(Verbs.INVALID, URI.from(""), Version.INVALID);
+        }
+
         return new RequestLine(
                 Verbs.from(separatedRequestLine[0]),
                 URI.from(separatedRequestLine[1]),

--- a/src/main/java/com/github/martingaston/application/http/Router.java
+++ b/src/main/java/com/github/martingaston/application/http/Router.java
@@ -12,6 +12,10 @@ public class Router {
     public Response respond(Request request) {
         Response.Builder response = createDefaultResponse();
 
+        if (invalidRequest(request)) {
+            return sendBadRequestResponse(response);
+        }
+
         if (invalidPath(request, routes)) {
             return sendNotFoundResponse(response);
         }
@@ -33,11 +37,19 @@ public class Router {
         return response.build();
     }
 
+    private boolean invalidRequest(Request request) {
+        return request.method() == Verbs.INVALID || !request.hasHeader("Host") || request.protocol() == Version.INVALID;
+    }
+
     private Response.Builder createDefaultResponse() {
         return new Response.Builder(Status.OK)
                     .addHeader("Connection", "close");
     }
 
+    private Response sendBadRequestResponse(Response.Builder response) {
+        response.status(Status.BAD_REQUEST);
+        return response.build();
+    }
     private static void handleValidRequest(Request request, Response.Builder response, Routes routes) {
         routes.handler(request).handle(request, response);
         response.status(Status.OK);

--- a/src/main/java/com/github/martingaston/application/http/Status.java
+++ b/src/main/java/com/github/martingaston/application/http/Status.java
@@ -1,7 +1,8 @@
 package com.github.martingaston.application.http;
 
 public enum Status {
-    OK ("200 OK"),
+    OK("200 OK"),
+    BAD_REQUEST("400 Bad Request"),
     NOT_FOUND("404 Not Found"),
     METHOD_NOT_ALLOWED("405 Method Not Allowed");
 

--- a/src/main/java/com/github/martingaston/application/transport/Port.java
+++ b/src/main/java/com/github/martingaston/application/transport/Port.java
@@ -3,7 +3,7 @@ package com.github.martingaston.application.transport;
 public class Port {
     private final int port;
     private final int MIN_PORT = 1024;
-    private final int MAX_PORT = 49151;
+    private final int MAX_PORT = 65535;
 
     public Port(int port) {
         validatePort(port);

--- a/src/test/java/com/github/martingaston/application/AppTest.java
+++ b/src/test/java/com/github/martingaston/application/AppTest.java
@@ -12,7 +12,7 @@ class AppTest {
     @DisplayName("POST /echo_body with body 'some body' returns 200 with body 'some body'")
     @Test
     void simplePostRequest() throws IOException {
-        byte[] request = "POST /echo_body HTTP/1.1\r\n\r\nsome body".getBytes();
+        byte[] request = "POST /echo_body HTTP/1.1\r\nHost: localhost:5000\r\n\r\nsome body".getBytes();
         byte[] response = "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 9\r\n\r\nsome body".getBytes();
 
         var connection = new MockConnection(request);
@@ -25,7 +25,7 @@ class AppTest {
     @DisplayName("POST /echo_body with body 'i wanna dance with some body' returns 200 with body 'i wanna dance with some body'")
     @Test
     void simplePostRequestDanceWithSomeBody() throws IOException {
-        byte[] request = "POST /echo_body HTTP/1.1\r\n\r\ni wanna dance with some body".getBytes();
+        byte[] request = "POST /echo_body HTTP/1.1\r\nHost: localhost:5000\r\n\r\ni wanna dance with some body".getBytes();
         byte[] response = "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 28\r\n\r\ni wanna dance with some body".getBytes();
 
         var connection = new MockConnection(request);
@@ -38,7 +38,7 @@ class AppTest {
     @DisplayName("HEAD /get_with_body returns a 200 with no body")
     @Test
     void headRequestReturnsNoBody() throws IOException {
-        byte[] request = "HEAD /get_with_body HTTP/1.1\r\n\r\n".getBytes();
+        byte[] request = "HEAD /get_with_body HTTP/1.1\r\nHost: localhost:5000\r\n\r\n".getBytes();
         byte[] response = "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n".getBytes();
 
         var connection = new MockConnection(request);
@@ -51,7 +51,7 @@ class AppTest {
     @DisplayName("GET /simple_get returns a 200 with no body")
     @Test
     void simpleGetReturns200WithNoBody() throws IOException {
-        byte[] request = "GET /simple_get HTTP/1.1\r\n\r\n".getBytes();
+        byte[] request = "GET /simple_get HTTP/1.1\r\nHost: localhost:5000\r\n\r\n".getBytes();
         byte[] response = "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n".getBytes();
 
         var connection = new MockConnection(request);

--- a/src/test/java/com/github/martingaston/application/communications/ReceiverTest.java
+++ b/src/test/java/com/github/martingaston/application/communications/ReceiverTest.java
@@ -20,4 +20,12 @@ class ReceiverTest {
 
     }
 
+    @DisplayName("Will return no/null input as an empty string")
+    @Test
+    void returnsEmptyStringOnNoInput() throws IOException {
+        ByteArrayInputStream input = new ByteArrayInputStream("".getBytes());
+        Receiver receiver = new Receiver(input);
+
+        assertThat(receiver.receiveLine()).isEqualTo("");
+    }
 }

--- a/src/test/java/com/github/martingaston/application/http/RequestTest.java
+++ b/src/test/java/com/github/martingaston/application/http/RequestTest.java
@@ -62,4 +62,23 @@ class RequestTest {
             assertThat(request.body()).isEqualTo(Body.from("some body"));
         }
     }
+
+    @Nested
+    @DisplayName("Will gracefully handle a null request")
+    class handlesInvalidRequests {
+        private ByteArrayOutputStream output = new ByteArrayOutputStream();
+        private Client client = new Client(null, output);
+        private Request request;
+
+        @BeforeEach
+        void init() throws IOException {
+            request = RequestParser.from(client);
+        }
+
+        @DisplayName("Will return an invalid method")
+        @Test
+        void hasInvalidMethod() {
+            assertThat(request.method()).isEqualTo(Verbs.INVALID);
+        }
+    }
 }

--- a/src/test/java/com/github/martingaston/application/http/RequestTest.java
+++ b/src/test/java/com/github/martingaston/application/http/RequestTest.java
@@ -66,8 +66,9 @@ class RequestTest {
     @Nested
     @DisplayName("Will gracefully handle a null request")
     class handlesInvalidRequests {
+        private ByteArrayInputStream input = new ByteArrayInputStream("".getBytes());
         private ByteArrayOutputStream output = new ByteArrayOutputStream();
-        private Client client = new Client(null, output);
+        private Client client = new Client(input, output);
         private Request request;
 
         @BeforeEach
@@ -79,6 +80,12 @@ class RequestTest {
         @Test
         void hasInvalidMethod() {
             assertThat(request.method()).isEqualTo(Verbs.INVALID);
+        }
+
+        @DisplayName("Will return an invalid version")
+        @Test
+        void hasInvalidVersion() {
+            assertThat(request.protocol()).isEqualTo(Version.INVALID);
         }
     }
 }

--- a/src/test/java/com/github/martingaston/application/http/RouterTest.java
+++ b/src/test/java/com/github/martingaston/application/http/RouterTest.java
@@ -185,13 +185,28 @@ class RouterTest {
     @DisplayName("Can handle invalid requests")
     @Nested
     class canRouteBadRequests {
-
         @DisplayName("With an invalid method")
         @Test void withInvalidMethod() {
            Request request = new Request(new RequestLine(Verbs.INVALID, URI.from("/echo_body"), Version.V1POINT1), headers, Body.from(""));
            Response response = router.respond(request);
 
            assertThat(response.status()).isEqualTo(Status.BAD_REQUEST);
+        }
+
+        @DisplayName("Without a Host header")
+        @Test void withoutHostHeader() {
+            Request request = new Request(new RequestLine(Verbs.POST, URI.from("/echo_body"), Version.V1POINT1), new Headers(), Body.from(""));
+            Response response = router.respond(request);
+
+            assertThat(response.status()).isEqualTo(Status.BAD_REQUEST);
+        }
+
+        @DisplayName("With an invalid HTTP version")
+        @Test void withInvalidVersion() {
+            Request request = new Request(new RequestLine(Verbs.POST, URI.from("/echo_body"), Version.INVALID), headers, Body.from(""));
+            Response response = router.respond(request);
+
+            assertThat(response.status()).isEqualTo(Status.BAD_REQUEST);
         }
     }
 }

--- a/src/test/java/com/github/martingaston/application/http/RouterTest.java
+++ b/src/test/java/com/github/martingaston/application/http/RouterTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.*;
 @DisplayName("A Router class")
 class RouterTest {
     static private Router router;
+    static private Headers headers;
 
     @BeforeAll
     static void initAll() {
@@ -27,6 +28,9 @@ class RouterTest {
         routes.put(URI.from("/method_options2"));
 
         router = new Router(routes);
+
+        headers = new Headers();
+        headers.add("Host", "localhost:5000");
     }
 
     @DisplayName("With a valid POST request")
@@ -37,7 +41,7 @@ class RouterTest {
 
         @BeforeEach
         void init() {
-            request = new Request(new RequestLine(Verbs.POST, URI.from("/echo_body"), Version.V1POINT1), new Headers(), Body.from("It is a truth universally acknowledged..."));
+            request = new Request(new RequestLine(Verbs.POST, URI.from("/echo_body"), Version.V1POINT1), headers, Body.from("It is a truth universally acknowledged..."));
             response = router.respond(request);
         }
 
@@ -62,7 +66,7 @@ class RouterTest {
 
         @BeforeEach
         void init() {
-            request = new Request(new RequestLine(Verbs.GET, URI.from("/get_with_body"), Version.V1POINT1), new Headers(), Body.from(""));
+            request = new Request(new RequestLine(Verbs.GET, URI.from("/get_with_body"), Version.V1POINT1), headers, Body.from(""));
             response = router.respond(request);
         }
 
@@ -81,7 +85,7 @@ class RouterTest {
 
         @BeforeEach
         void init() {
-            request = new Request(new RequestLine(Verbs.HEAD, URI.from("/simple_get"), Version.V1POINT1), new Headers(), Body.from(""));
+            request = new Request(new RequestLine(Verbs.HEAD, URI.from("/simple_get"), Version.V1POINT1), headers, Body.from(""));
             response = router.respond(request);
         }
 
@@ -112,7 +116,7 @@ class RouterTest {
 
         @BeforeEach
         void init() {
-            request = new Request(new RequestLine(Verbs.OPTIONS, URI.from("/method_options"), Version.V1POINT1), new Headers(), Body.from(""));
+            request = new Request(new RequestLine(Verbs.OPTIONS, URI.from("/method_options"), Version.V1POINT1), headers, Body.from(""));
             response = router.respond(request);
         }
 
@@ -143,7 +147,7 @@ class RouterTest {
 
         @BeforeEach
         void init() {
-            request = new Request(new RequestLine(Verbs.OPTIONS, URI.from("/method_options2"), Version.V1POINT1), new Headers(), Body.from(""));
+            request = new Request(new RequestLine(Verbs.OPTIONS, URI.from("/method_options2"), Version.V1POINT1), headers, Body.from(""));
             response = router.respond(request);
         }
 
@@ -172,9 +176,22 @@ class RouterTest {
         @DisplayName("Returns a 404 status code")
         @Test
         void returns404StatusCode() {
-            Request request = new Request(new RequestLine(Verbs.POST, URI.from("/totally_invalid_path"), Version.V1POINT1), new Headers(), Body.from("It is a truth universally acknowledged..."));
+            Request request = new Request(new RequestLine(Verbs.POST, URI.from("/totally_invalid_path"), Version.V1POINT1), headers, Body.from("It is a truth universally acknowledged..."));
             Response response = router.respond(request);
             assertThat(response.status()).isEqualTo(Status.NOT_FOUND);
+        }
+    }
+
+    @DisplayName("Can handle invalid requests")
+    @Nested
+    class canRouteBadRequests {
+
+        @DisplayName("With an invalid method")
+        @Test void withInvalidMethod() {
+           Request request = new Request(new RequestLine(Verbs.INVALID, URI.from("/echo_body"), Version.V1POINT1), headers, Body.from(""));
+           Response response = router.respond(request);
+
+           assertThat(response.status()).isEqualTo(Status.BAD_REQUEST);
         }
     }
 }

--- a/src/test/java/com/github/martingaston/application/transport/PortTest.java
+++ b/src/test/java/com/github/martingaston/application/transport/PortTest.java
@@ -12,6 +12,12 @@ class PortTest {
     }
 
     @Test
+    void createsOnEphemeralPort() {
+        var port = new Port(65535);
+        assertThat(port.get()).isEqualTo(65535);
+    }
+
+    @Test
     void willNotCreateOnSystemPort() {
         var thrown = catchThrowable(() -> new Port(80));
         assertThat(thrown).hasMessageContaining("Invalid port");


### PR DESCRIPTION
This PR adds support for the server to return a "400 Bad Request" for invalid requests received. 

This aspect of the design comes from deploying on Heroku, which seems to be occasionally throwing in empty requests to the server. While I'm not 100% sure what this is - randomly pinging the server to check it is alive? something to do with HTTP keep-alive? - it felt like the design warranted a way to respond accordingly to this.

Perhaps the best way to explore this further is to spin up a quick Flask/Sinatra server on Heroku and look at the logs there - see what's happening. 

These random (probably not random) requests would also be empty, which caused the `Receiver.readLine()` method to return null, which caused `NullPointerExceptions` to explode everything. A null response from the aforementioned method now returns an empty string, which is a less calamitous thing indeed. 👍 

The actual specifics of the response may change in time with my understanding of the protocol, but at least for now the server is responding in an accurate way. 